### PR TITLE
feat: add pincode protection to settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: build clean install install-debug install-release test help
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  build          - Build debug APK"
+	@echo "  build-release  - Build release APK"
+	@echo "  clean          - Clean build artifacts"
+	@echo "  install        - Install debug APK to connected device"
+	@echo "  install-release- Install release APK to connected device"
+	@echo "  uninstall      - Uninstall app from connected device"
+	@echo "  test           - Run tests"
+	@echo "  lint           - Run lint checks"
+	@echo "  assemble       - Build all variants"
+
+# Build debug APK
+build:
+	./gradlew assembleDebug
+
+# Build release APK
+build-release:
+	./gradlew assembleRelease
+
+# Build all variants
+assemble:
+	./gradlew assemble
+
+# Clean build artifacts
+clean:
+	./gradlew clean
+
+# Install debug APK to connected device
+install: build
+	./gradlew installDebug
+
+# Install debug APK without building (if already built)
+install-debug:
+	./gradlew installDebug
+
+# Install release APK to connected device
+install-release: build-release
+	./gradlew installRelease
+
+# Uninstall app from device
+uninstall:
+	./gradlew uninstallAll
+
+# Run tests
+test:
+	./gradlew test
+
+# Run lint checks
+lint:
+	./gradlew lint
+
+# Run app on connected device
+run: install
+	adb shell am start -n com.immichframe.immichframe/.MainActivity

--- a/app/src/main/res/xml/settings_view.xml
+++ b/app/src/main/res/xml/settings_view.xml
@@ -29,10 +29,17 @@
             android:defaultValue="false"
             android:key="showCurrentDate"
             android:title="Show Current Date?" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="Tamper Protection">
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="settingsPincode"
+            android:title="Protect access to these settings with pincode?" />
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="settingsLock"
-            android:title="Lock access to these settings?" />
+            android:title="Fully disable/lock access to these settings?" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="Screen Dimming">


### PR DESCRIPTION
Add the ability to block settings access behind a numerical passcode. This is perfect for protecting my frames from my inquisitve children.

`curl http://$IP:53287/settings` still works and bypasses the pin code. My kids aren't that smart (yet).

Some notes:
- Pincode is stored in plaintext, in a non-secure location. I think this is fine.
- Makefiles make life easy
- Claude assisted, but has been modified, reviewed and tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PIN code protection for settings access, allowing users to secure sensitive settings with a numeric password.
  * Added tamper protection controls to lock or fully disable access to settings.
  * Settings protection can be enabled or disabled from the new Tamper Protection category.

* **Chores**
  * Added build automation scripts for app compilation, testing, and deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->