### PR TITLE
feat: add ability to automatically return from settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+.PHONY: build clean install install-debug install-release test help
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  build          - Build debug APK"
+	@echo "  build-release  - Build release APK"
+	@echo "  clean          - Clean build artifacts"
+	@echo "  install        - Install debug APK to connected device"
+	@echo "  install-release- Install release APK to connected device"
+	@echo "  uninstall      - Uninstall app from connected device"
+	@echo "  test           - Run tests"
+	@echo "  lint           - Run lint checks"
+	@echo "  assemble       - Build all variants"
+
+# Build debug APK
+build:
+	./gradlew assembleDebug
+
+# Build release APK
+build-release:
+	./gradlew assembleRelease
+
+# Build all variants
+assemble:
+	./gradlew assemble
+
+# Clean build artifacts
+clean:
+	./gradlew clean
+
+# Install debug APK to connected device
+install: build
+	./gradlew installDebug
+
+# Install debug APK without building (if already built)
+install-debug:
+	./gradlew installDebug
+
+# Install release APK to connected device
+install-release: build-release
+	./gradlew installRelease
+
+# Uninstall app from device
+uninstall:
+	./gradlew uninstallAll
+
+# Run tests
+test:
+	./gradlew test
+
+# Run lint checks
+lint:
+	./gradlew lint
+
+# Run app on connected device
+run: install
+	adb shell am start -n com.immichframe.immichframe/.MainActivity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -36,6 +37,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
+
+        <service
+            android:name=".PowerButtonReturnService"
+            android:exported="false" />
 
         <activity
             android:name=".SettingsActivity"
@@ -78,6 +83,9 @@
                 android:name="android.appwidget.configuration"
                 android:resource="@layout/widget_config" />
         </receiver>
+        <receiver
+            android:name=".SettingsTimeoutReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/immichframe/immichframe/PowerButtonReturnService.kt
+++ b/app/src/main/java/com/immichframe/immichframe/PowerButtonReturnService.kt
@@ -1,0 +1,109 @@
+package com.immichframe.immichframe
+
+import android.app.ActivityManager
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.IBinder
+import android.util.Log
+
+/**
+ * Service that listens for screen-off events (power button press) and returns to ImmichFrame.
+ * Used when the user opens Android Settings and wants a quick way to return to the app.
+ */
+class PowerButtonReturnService : Service() {
+
+    private val screenOffReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == Intent.ACTION_SCREEN_OFF) {
+                Log.d(TAG, "Screen off detected, returning to ImmichFrame")
+                returnToApp()
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service created, registering screen-off receiver")
+
+        // Register broadcast receiver for screen off events
+        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+        registerReceiver(screenOffReceiver, filter)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.d(TAG, "Service started")
+        return START_NOT_STICKY // Don't restart if killed
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null // This is not a bound service
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Service destroyed, unregistering receiver")
+        try {
+            unregisterReceiver(screenOffReceiver)
+        } catch (e: IllegalArgumentException) {
+            // Receiver was already unregistered, ignore
+            Log.w(TAG, "Receiver already unregistered", e)
+        }
+    }
+
+    private fun returnToApp() {
+        // Check if app is already in foreground
+        if (isAppInForeground()) {
+            Log.d(TAG, "App already in foreground, skipping return")
+            stopSelf()
+            return
+        }
+
+        // Cancel the timeout alarm since we're returning via power button
+        SettingsTimeoutReceiver.cancelTimeout(this)
+
+        // Launch ImmichFrame and bring it to foreground
+        Log.d(TAG, "App in background, bringing to foreground via power button")
+        val returnIntent = packageManager.getLaunchIntentForPackage(packageName)
+        returnIntent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        startActivity(returnIntent)
+
+        // Stop this service since we're done
+        stopSelf()
+    }
+
+    private fun isAppInForeground(): Boolean {
+        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val appProcesses = activityManager.runningAppProcesses ?: return false
+
+        for (appProcess in appProcesses) {
+            if (appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+                appProcess.processName == packageName) {
+                return true
+            }
+        }
+        return false
+    }
+
+    companion object {
+        private const val TAG = "PowerButtonReturnService"
+
+        /**
+         * Start the service to begin listening for power button presses
+         */
+        fun start(context: Context) {
+            val intent = Intent(context, PowerButtonReturnService::class.java)
+            context.startService(intent)
+        }
+
+        /**
+         * Stop the service to stop listening for power button presses
+         */
+        fun stop(context: Context) {
+            val intent = Intent(context, PowerButtonReturnService::class.java)
+            context.stopService(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/immichframe/immichframe/SettingsFragment.kt
+++ b/app/src/main/java/com/immichframe/immichframe/SettingsFragment.kt
@@ -4,8 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.provider.Settings
 import android.text.InputType
 import android.widget.Toast
@@ -94,14 +92,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
             // Only show Toast + auto-return on Android 9 and below
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-                Toast.makeText(context, "Returning to app in 2 minutes…", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, "Short press power button to return, or wait 2 minutes for auto-return", Toast.LENGTH_LONG).show()
 
-                // Schedule return after 2 minutes
-                Handler(Looper.getMainLooper()).postDelayed({
-                    val returnIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-                    returnIntent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    context.startActivity(returnIntent)
-                }, 2 * 60 * 1000)
+                // Start the power button listener service
+                PowerButtonReturnService.start(context)
+
+                // Schedule return after 2 minutes using AlarmManager (backup if power button not pressed)
+                SettingsTimeoutReceiver.scheduleTimeout(context)
             }
 
             // Launch Android settings

--- a/app/src/main/java/com/immichframe/immichframe/SettingsTimeoutReceiver.kt
+++ b/app/src/main/java/com/immichframe/immichframe/SettingsTimeoutReceiver.kt
@@ -1,0 +1,115 @@
+package com.immichframe.immichframe
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+/**
+ * BroadcastReceiver that handles the 2-minute timeout when user opens Android Settings.
+ * When the alarm fires, it brings ImmichFrame back to the foreground and stops the
+ * PowerButtonReturnService.
+ */
+class SettingsTimeoutReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "Settings timeout alarm fired, returning to ImmichFrame")
+
+        // Stop the power button service since we're returning via timeout
+        PowerButtonReturnService.stop(context)
+
+        // Launch ImmichFrame and bring it to foreground
+        val returnIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+        returnIntent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        context.startActivity(returnIntent)
+    }
+
+    companion object {
+        private const val TAG = "SettingsTimeoutReceiver"
+        private const val ACTION_TIMEOUT = "com.immichframe.immichframe.SETTINGS_TIMEOUT"
+        private const val TIMEOUT_MILLIS = 2 * 60 * 1000L // 2 minutes
+
+        /**
+         * Schedule the 2-minute timeout alarm
+         */
+        fun scheduleTimeout(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, SettingsTimeoutReceiver::class.java).apply {
+                action = ACTION_TIMEOUT
+            }
+
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+
+            val pendingIntent = PendingIntent.getBroadcast(context, 0, intent, flags)
+
+            // Schedule alarm for 2 minutes from now
+            val triggerTime = System.currentTimeMillis() + TIMEOUT_MILLIS
+
+            when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+                    // Android 12+ - check if we can schedule exact alarms
+                    if (alarmManager.canScheduleExactAlarms()) {
+                        alarmManager.setExactAndAllowWhileIdle(
+                            AlarmManager.RTC_WAKEUP,
+                            triggerTime,
+                            pendingIntent
+                        )
+                        Log.d(TAG, "Settings timeout alarm scheduled (exact) for 2 minutes from now")
+                    } else {
+                        // Fallback to inexact alarm if exact permission not granted
+                        alarmManager.setAndAllowWhileIdle(
+                            AlarmManager.RTC_WAKEUP,
+                            triggerTime,
+                            pendingIntent
+                        )
+                        Log.d(TAG, "Settings timeout alarm scheduled (inexact) for ~2 minutes from now")
+                    }
+                }
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+                    alarmManager.setExactAndAllowWhileIdle(
+                        AlarmManager.RTC_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                    Log.d(TAG, "Settings timeout alarm scheduled (exact) for 2 minutes from now")
+                }
+                else -> {
+                    alarmManager.setExact(
+                        AlarmManager.RTC_WAKEUP,
+                        triggerTime,
+                        pendingIntent
+                    )
+                    Log.d(TAG, "Settings timeout alarm scheduled (exact) for 2 minutes from now")
+                }
+            }
+        }
+
+        /**
+         * Cancel the timeout alarm
+         */
+        fun cancelTimeout(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, SettingsTimeoutReceiver::class.java).apply {
+                action = ACTION_TIMEOUT
+            }
+
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+
+            val pendingIntent = PendingIntent.getBroadcast(context, 0, intent, flags)
+            alarmManager.cancel(pendingIntent)
+
+            Log.d(TAG, "Settings timeout alarm cancelled")
+        }
+    }
+}


### PR DESCRIPTION
Waiting for the 2 minutes to elapse to returne to the app is tedious.

There is only one reliable button on the device, the power button.

If the user opens the Android settings through the app, we continue to have a 2 minute time out.

However, this PR also adds the ability to return to the app quickly but tapping the power button round the back of the device. Screen off, screen on and you're back inside Immich Frame app.

I'll accept if you don't think is worth the complexity but I'll keep running it in my fork.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Power button can now return users to ImmichFrame when the app is backgrounded.
  * Settings flow now shows updated messaging and uses a reliable 2‑minute backup timeout to auto-return the app.

* **Chores**
  * Added Makefile targets to streamline build, install, test, lint, and run workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->