### PR TITLE
Screen dim, set back to BRIGHTNESS_OVERRIDE_NONE instead of 1.0

### DIFF
--- a/app/src/main/java/com/immichframe/immichframe/MainActivity.kt
+++ b/app/src/main/java/com/immichframe/immichframe/MainActivity.kt
@@ -521,7 +521,7 @@ class MainActivity : AppCompatActivity() {
             dimOverlay.visibility = View.GONE
             val lp = WindowManager.LayoutParams()
             lp.copyFrom(window.attributes)
-            lp.screenBrightness = 1f
+            lp.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
             window.attributes = lp
         }
         if (useWebView) {
@@ -707,7 +707,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun screenBrightnessAction(brightness: Float) {
         val lp = window.attributes
-        lp.screenBrightness = brightness
+        if (brightness < 0) {
+            lp.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+        } else {
+            lp.screenBrightness = brightness
+        }
         window.attributes = lp
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved brightness control handling when screen-dimming is disabled. The app now properly clears brightness overrides instead of forcing a fixed brightness level, resulting in more accurate display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->